### PR TITLE
删除随机数，防止随机数过大导致循环无响应

### DIFF
--- a/modules/guard.js
+++ b/modules/guard.js
@@ -82,7 +82,7 @@ const main = async () => {
       }
     }
 
-    await sleep(5 * 1000 + Math.random() * 60 * 1000)
+    await sleep(5 * 1000)
   }
 }
 


### PR DESCRIPTION
由于index.js中采用的是无限循环，在执行guard函数时，当出现舰长经验领取错误的时候会有一个等待随机数秒以后重新执行循环，但随机数并未设置最大值，可能导致等待时间过长，故删除该随机数。