### PR TITLE
本地化拉取舰长列表

### DIFF
--- a/modules/guard.js
+++ b/modules/guard.js
@@ -183,7 +183,7 @@ async function getGuardLocal() {
     }
     await sleep(20);
   }
-  if (config.get('debug')) console.log(chalk.gray(retarr))
+  if (config.get('debug')) console.log(chalk.gray(JSON.stringify(retarr)))
   logger.notice(`guard: 拉取完成`)
   return retarr;
 }

--- a/modules/guard.js
+++ b/modules/guard.js
@@ -149,16 +149,16 @@ async function getGuardLocal() {
 
   // 循环拉取信息，利用异步函数快速抓取
   forArr.forEach(async (i) => {
-    const asyncBody = await getLiveList(i);
+    const listBody = await getLiveList(i);
 
     // 当拉取成功
-    if (asyncBody && asyncBody.code === 0) {
+    if (listBody && listBody.code === 0) {
 
       // 声明异步子状态
       let flagAsync = 0;
 
       // 获取该页房间列表
-      const backList = asyncBody.data.list;
+      const backList = listBody.data.list;
       backList.forEach(async (eachRoom) => {
 
         // web_pendent有内容时，房间内有活动状态，大概率有舰长
@@ -200,7 +200,7 @@ async function getGuardLocal() {
         await sleep(100);
       }
     } else {
-      if (config.get('debug') && asyncBody) console.log(asyncBody.msg);
+      if (config.get('debug') && listBody) console.log(listBody.msg);
     }
 
     // 增加一次flag，表示该次异步已完成

--- a/modules/guard.js
+++ b/modules/guard.js
@@ -32,8 +32,7 @@ const main = async () => {
   const list = await getGuardLocal()
   // const list = await getGuardList(uid)
   
-
-  let originList = list.filter(item => !list_cache.includes(item.GuardId))
+  const originList = list.filter(item => !list_cache.includes(item.GuardId))
   if (list_cache.length > 10000) list_cache.splice(0, 9000)
 
   for (const currentItem of originList) {


### PR DESCRIPTION
测试了一下，内容提供的api有很大的不稳定因素，时常发生漏包、过时包以及网站响应超时，通过app抓包找到了匿名抓取房间信息的方式，通过遍历所有在线的房间来检查房间的舰长抽奖。
于是这里pull一个本地拉取舰长列表的分支，可以考虑修改后合并。