### PR TITLE
修复签到问题

### DIFF
--- a/modules/tasks.js
+++ b/modules/tasks.js
@@ -69,17 +69,8 @@ const check_sign_info = async () => {
   {
     logger.info('正在尝试网页签到')
     let {body} = await got.get('https://api.live.bilibili.com/sign/doSign', {json: true})
-    if (body.code === 0 && body.message === 'OK') {
-      logger.info(`签到成功，您已经连续签到 ${body.data.hadSignDays} 天，获得${body.data.text}${body.data.specialText}`)
-      return
-    }
-  }
-  await sleep(2000)
-  {
-    logger.info('正在尝试客户端签到')
-    let {body} = await got.get('https://api.live.bilibili.com/appUser/getSignInfo', {query: sign({}), json: true})
-    if (body.code === 0 && body.message === 'OK') {
-      logger.info(`签到成功，您已经连续签到 ${body.data.hadSignDays} 天，获得${body.data.text}${body.data.specialText}`)
+    if (body.code === 0 && body.message === '0') {
+      logger.notice(`签到成功，您已经连续签到 ${body.data.hadSignDays} 天，获得${body.data.text}${body.data.specialText}`)
       return
     }
   }


### PR DESCRIPTION
1. 客户端签到接口已被废弃，故删除
2. 网页签到成功后返回的body.message现在是"0"而非"OK"，造成无法显示签到成功信息
3. 签到成功的level改成notice，与其他成功信息统一